### PR TITLE
Specifying targetSdkVersion

### DIFF
--- a/PaystackInline.Forms.Plugin/Renderer.android.cs
+++ b/PaystackInline.Forms.Plugin/Renderer.android.cs
@@ -20,6 +20,11 @@ namespace Plugin.PaystackInline.Forms.Plugin.Droid
         private const string CloseJavaScriptFunction = "function invokeCSharpCloseAction(){jsBridge.invokeCloseAction();}";
         private Context _context;
 
+        /// <summary>
+        /// Action to load Js after OnPageFinished Method Override
+        /// </summary>
+        internal static Action InjectJsAction = null;
+
         public PaystackWebViewRenderer(Context context) : base(context)
         {
             _context = context;
@@ -51,8 +56,11 @@ namespace Plugin.PaystackInline.Forms.Plugin.Droid
 
 
                 Control.LoadDataWithBaseURL("", content, "text/html", "UTF-8", null);
-                InjectJS(CallBackJavaScriptFunction);
-                InjectJS(CloseJavaScriptFunction);
+                InjectJsAction = new Action(() =>
+                {
+                    InjectJS(CallBackJavaScriptFunction);
+                    InjectJS(CloseJavaScriptFunction);
+                });
             }
         }
 
@@ -124,6 +132,7 @@ namespace Plugin.PaystackInline.Forms.Plugin.Droid
             base.OnPageFinished(view, url);
 
             view.LoadUrl(string.Format("javascript:payWithPaystack({0})", Record));
+            PaystackWebViewRenderer.InjectJsAction?.Invoke();
         }
         public override void OnPageStarted(Android.Webkit.WebView view, string url, Bitmap favicon)
         {

--- a/PaystackInline.Forms.Plugin/readme.txt
+++ b/PaystackInline.Forms.Plugin/readme.txt
@@ -1,6 +1,1 @@
 You need to add a reference to Mono.Android.Export.dll in your Android Project
-
-
-
-Android:
-Set the Target Android Version: to Use Comple using SDK version

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Paystack Inline Payment Plugin for Xamarin Forms and Windows
 
 ## Android Requirements
 1. Add a reference to Mono.Android.Export, or a compiler error will result.
-2. On Android Oreo ensure that the Android manifest sets the Target Android version to Automatic. Otherwise, the iframe won't load.
 
 ## Usage
    ### XAML


### PR DESCRIPTION
Moved logic for injecting C# method as JavaScript  to the OnPageFinished overrride method in Android project to follow Androids specification of loading JavaScript after page has loaded. This ensures targetSdkVersion can be specified while the C# callback action gets invoked from the JavaScript in the WebView